### PR TITLE
Make Seiya Salga script match subdomains

### DIFF
--- a/seiya-saiga-spoilers.user.js
+++ b/seiya-saiga-spoilers.user.js
@@ -4,7 +4,7 @@
 // @homepageURL https://github.com/MarvNC/vn-userscripts
 // @match       https://*.seiya-saiga.com/game/*
 // @grant       GM_addStyle
-// @version     1.0
+// @version     1.1
 // @author      Marv
 // @description Seiya Saiga Spoilers
 // @run-at      document-load

--- a/seiya-saiga-spoilers.user.js
+++ b/seiya-saiga-spoilers.user.js
@@ -2,7 +2,7 @@
 // @name        Seiya Saiga Spoilers
 // @namespace   Marv
 // @homepageURL https://github.com/MarvNC/vn-userscripts
-// @match       https://seiya-saiga.com/game/*
+// @match       https://*.seiya-saiga.com/game/*
 // @grant       GM_addStyle
 // @version     1.0
 // @author      Marv


### PR DESCRIPTION
Seiya Saiga uses subdomains to separate some of its guides out and the intended behavior is for it to match those other guides as well.

The following is a guide that should be matched but is not under the current script, 

https://galge.seiya-saiga.com/game/innocentgrey/flowers.html

The following is also a guide that should be matched but this one still doesn't hide the choices properly which I'm assuming is due to the choice and it's responses being on different lines.

https://galge.seiya-saiga.com/game/5pb/chaos_head_pc.html

https://galge.seiya-saiga.com/ for more

I have not tested the change on different pages.